### PR TITLE
Fix print statements to be python3-compatible

### DIFF
--- a/binstar_client/commands/_files.py
+++ b/binstar_client/commands/_files.py
@@ -34,9 +34,9 @@ def main(args):
         for file in args.files:
             attrs = detect(binstar, spec.user, spec.package, file)
             with open(file) as fd:
-                print 'Uploading %s ... ' % file
+                print('Uploading %s ... ' % file)
                 binstar.upload(spec.user, spec.package, spec.version, basename(file), fd, args.description, **attrs)
-        print '... done'
+        print('... done')
     elif args.action == 'download':
         requests_handle = binstar.download(spec.user, spec.package, spec.version, spec.basename)
 
@@ -50,12 +50,12 @@ def main(args):
     elif args.action == 'list':
         release = binstar.release(spec.user, spec.package, spec.version)
         for dist in release.get('distributions',[]):
-            print '%(basename)s id: %(_id)s' % dist
+            print('%(basename)s id: %(_id)s' % dist)
             for key_value in dist['attrs'].items():
-                print '  + %s: %r' % key_value
+                print('  + %s: %r' % key_value)
     elif args.action == 'remove':
-        print spec.user, spec.package, spec.version, spec.basename, spec.attrs
-        print binstar.remove_dist(spec.user, spec.package, spec.version, spec.basename, spec.attrs)
+        print(spec.user, spec.package, spec.version, spec.basename, spec.attrs)
+        print(binstar.remove_dist(spec.user, spec.package, spec.version, spec.basename, spec.attrs))
     else:
         raise NotImplementedError(args.action)
 

--- a/binstar_client/commands/_release.py
+++ b/binstar_client/commands/_release.py
@@ -22,7 +22,7 @@ def main(args):
         binstar.add_release(user, package, version, {}, announce, description)
     elif args.action == 'show':
         release = binstar.release(user, package, version)
-        print release
+        print(release)
     else:
         raise NotImplementedError(args.action)
 

--- a/example-packages/pypi/package1/__init__.py
+++ b/example-packages/pypi/package1/__init__.py
@@ -1,1 +1,1 @@
-print 'hello'
+print('hello')


### PR DESCRIPTION
It may be desirable in some cases to import print_function if running under python2, but this should be at least syntactically valid.