### PR TITLE
Alias conda-server to binstar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     entry_points={
           'console_scripts': [
               'binstar = binstar_client.scripts.cli:main',
+              'conda-server = binstar_client.scripts.cli:main',
               ]
                  },
 


### PR DESCRIPTION
Users can now run `conda server ...` in place of `binstar ...`. This change is backwards compatible.

cc @asmeurer @csoja @ilanschnell 