### PR TITLE
Getting the test cases to pass by fixing up the parsestr unicode problem

### DIFF
--- a/binstar_client/inspect_package/pypi.py
+++ b/binstar_client/inspect_package/pypi.py
@@ -230,7 +230,7 @@ def inspect_pypi_package_sdist(filename, fileobj):
         if data is None:
             raise errors.NoMetadataError("Could not find *.egg-info/PKG-INFO file in pypi sdist")
 
-    config_items = Parser().parsestr(data).items()
+    config_items = Parser().parsestr(data.encode("UTF-8", "replace")).items()
     attrs = dict(config_items)
     name = pop_key(attrs, 'Name', None)
 
@@ -270,7 +270,7 @@ def inspect_pypi_package_egg(filename, fileobj):
     if data is None:
         raise errors.NoMetadataError("Could not find EGG-INFO/PKG-INFO file in pypi sdist")
 
-    attrs = dict(Parser().parsestr(data).items())
+    attrs = dict(Parser().parsestr(data.encode("UTF-8", "replace")).items())
 
     package_data = {'name': pop_key(attrs, 'Name'),
                     'summary': pop_key(attrs, 'Summary', None),


### PR DESCRIPTION
This problem is holding up an ongoing release we're working on that
will be the debut release on binstar.org for our packages. Please
merge quickly.

Would you be interested in me creating a travis CI for binstar? The test cases would have caught the above problem. 