### PR TITLE
Improve notebook's versions readability #171

### DIFF
--- a/binstar_client/utils/notebook/uploader.py
+++ b/binstar_client/utils/notebook/uploader.py
@@ -65,7 +65,7 @@ class Uploader(object):
     @property
     def version(self):
         if self._version is None:
-            self._version = str(int(time.time()))
+            self._version = time.strftime('%Y.%m.%d-%H%M')
         return self._version
 
     @property


### PR DESCRIPTION
Now versions will look like:
![screen shot 2015-06-30 at 18 00 20](https://cloud.githubusercontent.com/assets/55977/8444024/f7ff9d2c-1f51-11e5-983b-03f30bc24abd.png)

I believe we need the hour/minute information to avoid having problems with notebooks with the same version

@srossross @LilaHickey 