### PR TITLE
Notebook's name won't have ipynb at the end anymore

### DIFF
--- a/binstar_client/utils/notebook/tests/test_uploader.py
+++ b/binstar_client/utils/notebook/tests/test_uploader.py
@@ -36,6 +36,11 @@ class UploaderTestCase(unittest.TestCase):
         uploader = Uploader(binstar, 'project')
         self.assertIsInstance(uploader.version, str)
 
+    def test_package_name(self):
+        binstar = mock.MagicMock()
+        uploader = Uploader(binstar, '~/notebooks/my notebook.ipynb')
+        self.assertEqual(uploader.project, 'my-notebook')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_client/utils/notebook/uploader.py
+++ b/binstar_client/utils/notebook/uploader.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from os.path import basename
 from binstar_client import errors
@@ -55,7 +56,7 @@ class Uploader(object):
 
     @property
     def project(self):
-        return parameterize(os.path.basename(self.filepath))
+        return re.sub('\-ipynb$', '', parameterize(os.path.basename(self.filepath)))
 
     @property
     def username(self):


### PR DESCRIPTION
# Problem
Once the notebook's been uploaded it has `-ipynb` at the end. Example: `https://anaconda.org/malev/notebook-ipynb`

# Solution
Remove `-ipynb` from the end of the name before creating the project.

